### PR TITLE
Support vendors in blade directive and Request

### DIFF
--- a/resources/views/javaScriptSetup.blade.php
+++ b/resources/views/javaScriptSetup.blade.php
@@ -3,5 +3,5 @@
     @if(config('paddle.sandbox_environment'))
     Paddle.Environment.set('sandbox');
     @endif
-    Paddle.Setup(@json(['vendor' => (int) config('paddle.vendor_id')]));
+    Paddle.Setup(@json(['vendor' => (int) $vendorId]));
 </script>

--- a/src/Api/Request.php
+++ b/src/Api/Request.php
@@ -98,11 +98,13 @@ class Request
 
         $method = $this->method;
 
-        $data = $this->getData() + ['vendor_id' => config('paddle.vendor_id')];
+        $data = ['vendor_id' => config('paddle.vendor_id')];
 
         if ($method === static::METHOD_POST) {
             $data['vendor_auth_code'] = config('paddle.vendor_auth_code');
         }
+
+        $data = array_merge($data, $this->getData());
 
         $url = $this->url();
 

--- a/src/PaddleServiceProvider.php
+++ b/src/PaddleServiceProvider.php
@@ -27,8 +27,15 @@ class PaddleServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__ . '/../resources/views', 'paddle');
 
-        Blade::directive('paddle', function () {
-            return "<?php echo view('paddle::javaScriptSetup'); ?>";
+        
+        Blade::directive('paddle', function ($vendorId = false) {
+            if (!$vendorId) {
+                $vendorId = config('paddle.vendor_id');
+            }
+
+            return "<?php 
+                echo view('paddle::javaScriptSetup', ['vendorId' => " . $vendorId . "]);
+            ?>";
         });
     }
 

--- a/tests/DirectiveTest.php
+++ b/tests/DirectiveTest.php
@@ -47,4 +47,19 @@ class DirectiveTest extends TestCase
         $this->assertStringContainsString("Paddle.Environment.set('sandbox');", $rendered);
         $this->assertStringContainsString('Paddle.Setup({"vendor":20});', $rendered);
     }
+
+    /** @test */
+    public function it_includes_paddle_js_with_vendor_id()
+    {
+        View::addLocation(__DIR__);
+        config([
+            'paddle' => [
+                'vendor_id' => 20,
+            ],
+        ]);
+
+        $rendered = (string) view('dummy-vendor', ['vendor' => 50]);
+
+        $this->assertStringContainsString('Paddle.Setup({"vendor":50});', $rendered);
+    }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -69,4 +69,31 @@ class RequestTest extends TestCase
 
         $this->fail('Should have thrown InvalidDataException');
     }
+
+    /** @test */
+    public function it_can_set_the_vendor_keys_into_payload_by_array()
+    {
+        config([
+            'paddle' => [
+                'vendor_id' => 20,
+                'vendor_auth_code' => '123',
+            ],
+        ]);
+        $request = (new Api)->product()->generatePayLink([
+                'product_id'       => 10,
+                'customer_email'   => 'test@example.com',
+                'passthrough'      => ['team_id' => 20],
+                'vendor_id'        => 50,
+                'vendor_auth_code' => 'efg'
+            ]);
+
+        $this->assertEquals([
+                'product_id'       => 10,
+                'customer_email'   => 'test@example.com',
+                'passthrough'      => json_encode(['team_id' => 20]),
+                'vendor_id'        => 50,
+                'vendor_auth_code' => 'efg'
+
+            ], $request->getData());
+    }
 }

--- a/tests/dummy-vendor.blade.php
+++ b/tests/dummy-vendor.blade.php
@@ -1,0 +1,1 @@
+@paddle($vendor)


### PR DESCRIPTION
I mentioned this feature in #28.

I added support for multi vendors via configuration in Request:

Usage:
```
Paddle::product()
        ->generatePayLink([
            'vendor_id' => '44334',
            'vendor_auth_code' => 'fdfsdfsdf'
        ])
        ->productId('5345')
        ->send();
```

Also, I added support for multi vendors in blade directive:
```
@paddle(123)
```

Both changes are covered in unit tests. What have left is to add support for `verifySignature` in `WebhookController`, but only this method can support overloading public_key from config, not the controller because I think we can't support multi-vendors in that case. Users need to create own controllers because they know where from they will read `public_key`.

We can discuss Do we want to change `WebhookController` or not. 


        